### PR TITLE
Fixed bug in reporting private key incompatibility with synchronize mode

### DIFF
--- a/dist/Remote.js
+++ b/dist/Remote.js
@@ -180,7 +180,7 @@ module.exports = function () {
 
             // Use privateKey
             else if (this.options.privateKeyFile != null) {
-                    logger.fatal('PrivateKey not compatible with synchronize mode.');
+                    _this3.logger.fatal('PrivateKey not compatible with synchronize mode.');
                 }
 
             // Concat


### PR DESCRIPTION
Logger was incorrectly referenced, so users trying to use synchronize mode but with a key file, experienced a Fatal Error: logger not defined error.