### PR TITLE
Fix hooks with string command.

### DIFF
--- a/src/ssh-deploy-release.js
+++ b/src/ssh-deploy-release.js
@@ -653,14 +653,13 @@ module.exports = class {
                 return;
             }
 
-            // Support single command as a string
-            if (typeof commandsFunctionReturnValue === 'string') {
-                commandsFunctionReturnValue = [commandsFunctionReturnValue];
-            }
-
             commands = commandsFunctionReturnValue;
         }
 
+        // Support single command as a string
+        if (typeof commands === 'string') {
+            commands = [commands];
+        }
 
         // Nothing to execute
         if (!commands || commands.length == 0) {


### PR DESCRIPTION
async.eachSeries runs commands. If commands is a string it tries to run
each character as a command. middlewareCallbackExecute already mapped
a string result of a function to [string]. This change moves that
transformation so it appies to the result of a function as well as a
raw string.