### PR TITLE
Pass onKeyboardInteractive callback to ssh2

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,12 @@ SCP connection timeout duration.
 Default : `20000`
 
 
+#### options.onKeyboardInteractive
+Callback passed to `ssh2` [client event](https://github.com/mscdex/ssh2/blob/v0.8.x/README.md#client-events) 
+`keyboard-interactive`.
+
+Type: `function (name, descr, lang, prompts, finish)`
+
 ### Path
 #### options.currentReleaseLink
 Name of the current release symbolic link. Relative to `deployPath`.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.0.4",
+  "version": "3.0.5",
   "name": "ssh-deploy-release",
   "description": "Deploy release on remote server over ssh.",
   "author": {

--- a/src/Remote.js
+++ b/src/Remote.js
@@ -43,6 +43,10 @@ module.exports = class {
         this.connection.on('error', onError);
         this.connection.on('close', onClose);
 
+        if (this.options.onKeyboardInteractive) {
+            this.connection.on('keyboard-interactive', this.options.onKeyboardInteractive);
+        }
+
         const connectionOptions = Object.assign({}, this.options);
 
         // If debug is enabled, proxy output to console.log


### PR DESCRIPTION
Hello, 
if you want to use `tryKeyboard == true`, you have to provide `keyboard-interactive` function to SSH2, but there was no such possibility. I have just added support for passing `keyboard-interactive` to `ssh2` using `options` object.

Here is working example:

```js
const Deployer = require('ssh-deploy-release');

const options = {
  localPath: 'build',
  host: process.env.REMOTE_HOST,
  username: process.env.REMOTE_USER,
  password: process.env.REMOTE_PASSWORD,
  deployPath: process.env.REMOTE_PATH,
  currentReleaseLink: 'current',
  archiveType: 'zip',
  tryKeyboard: true,
  onKeyboardInteractive: function (name, descr, lang, prompts, finish) {
    return finish([this.config.password]);
  }
};

const deployer = new Deployer(options);
deployer.deployRelease(() => {
  console.log('Deployed!')
});
```

I have to admit I am not a JS developer, so I hope my implementation is not that bad.  Our servers support keyboard-interactive authentication only (it's kinda default behavior on majority of production servers).